### PR TITLE
Fix: 경로 api 불러오기 오류로 이전 코드 롤백

### DIFF
--- a/safepath/src/screens/ReportScreen.jsx
+++ b/safepath/src/screens/ReportScreen.jsx
@@ -24,7 +24,9 @@ const getPlaceLabel = (place) => {
 
 const getCoordsFromPath = (path) => {
   if (!path) return null;
-  return path.coordinates || path.coords || path.points || null;
+  return (
+    path.coordinates || path.coords || path.points || null
+  );
 };
 
 const getDistanceFromPath = (path) => {
@@ -98,11 +100,10 @@ export default function ReportScreen() {
     { lat: 37.5453, lng: 127.0582 },
   ];
 
-  const cardPaths = Array.isArray(paths) ? paths.slice(0, 3) : [];
+  const cardPaths =
+    paths && paths.length > 0 ? paths.slice(0, 3) : [null, null, null];
 
   const handleOpenDetail = async (path, index) => {
-    if (!path) return;
-
     setIsDetailOpen(true);
     setIsReportLoading(true);
     setReportError(null);
@@ -214,8 +215,6 @@ export default function ReportScreen() {
       <div className="absolute left-1/2 top-[47%] z-20 w-full -translate-x-1/2 -translate-y-1/2 ">
         <div className="flex gap-4 overflow-x-auto snap-x snap-mandatory no-scrollbar pl-10 pr-10">
           {cardPaths.map((path, i) => {
-            if (!path) return null;
-
             const rawCoords = getCoordsFromPath(path);
             const previewPath =
               Array.isArray(rawCoords) && rawCoords.length > 0


### PR DESCRIPTION
report 화면일 때 수정 시,  해당 경로에 사용되는 등급(점수)가 반영 되나 새로고침 후 재시작 시 리포트 카드가 사라지는 오류 발생 -> 이전 코드 롤백